### PR TITLE
Fix rooms and emitters dependencies running example

### DIFF
--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -1,9 +1,15 @@
 var PrimusIO = require('../../');
+var Emitter = require('primus-emitter');
+var Rooms = require('primus-rooms');
 var http = require('http');
 var server = http.createServer();
 
 // The Primus server
 var primus = new PrimusIO(server, { transformer: 'websockets', parser: 'JSON' });
+
+// Add plugins needed for room and emit functionality
+primus.use('rooms', Rooms);
+primus.use('emitter', Emitter);
 
 // Listen to incoming connections
 primus.on('connection', function(spark){

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -11,6 +11,8 @@
     "engine.io": "~0.6.3",
     "socket.io": "~0.9.16",
     "ws": "~0.4.27",
-    "sockjs": "~0.3.7"
+    "sockjs": "~0.3.7",
+    "primus-rooms": "~3.1.0",
+    "primus-emitter": "~3.0.3
   }
 }


### PR DESCRIPTION
The NodeJS server examples packaged with Primus won't work without including the Rooms and Emitters plugins and it takes some figuring to understand why the example doesn't work out of the box.